### PR TITLE
Refactor CubeView to MonoBehaviour

### DIFF
--- a/Assets/Prefabs/Canvas.prefab
+++ b/Assets/Prefabs/Canvas.prefab
@@ -1,0 +1,66 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: UICanvas
+  m_Component:
+  - component: {fileID: 2}
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+  m_Layer: 5
+  m_IsActive: 1
+--- !u!224 &2
+Canvas:
+  m_RenderMode: 0
+--- !u!225 &3
+CanvasScaler:
+  m_UIScaleMode: 1
+--- !u!223 &4
+GraphicRaycaster:
+--- !u!1 &10
+GameObject:
+  m_Name: JumpButton
+  m_Component:
+  - component: {fileID: 12}
+  - component: {fileID: 13}
+  - component: {fileID: 14}
+  m_Layer: 5
+  m_Parent: {fileID: 1}
+--- !u!224 &12
+RectTransform:
+--- !u!114 &13
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 3}
+--- !u!114 &14
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 3}
+--- !u!1 &20
+GameObject:
+  m_Name: RestartButton
+  m_Component:
+  - component: {fileID: 22}
+  - component: {fileID: 23}
+  - component: {fileID: 24}
+  m_Layer: 5
+  m_Parent: {fileID: 1}
+--- !u!224 &22
+RectTransform:
+--- !u!114 &23
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 3}
+--- !u!114 &24
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 3}
+--- !u!1 &30
+GameObject:
+  m_Name: ResultText
+  m_Component:
+  - component: {fileID: 32}
+  - component: {fileID: 33}
+  m_Layer: 5
+  m_Parent: {fileID: 1}
+--- !u!224 &32
+RectTransform:
+--- !u!114 &33
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 3}

--- a/Assets/Prefabs/Canvas.prefab.meta
+++ b/Assets/Prefabs/Canvas.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: abd02747c79b4128ba4324bdfe3f086b
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Prefabs/Cube.prefab
+++ b/Assets/Prefabs/Cube.prefab
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: Cube
+  m_Component:
+  - component: {fileID: 4}
+  - component: {fileID: 33}
+  - component: {fileID: 23}
+  m_Layer: 0
+  m_TagString: Player
+  m_IsActive: 1
+--- !u!4 &4
+Transform:
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &33
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 0000000000000000f000000000000000, type: 0}
+--- !u!23 &23
+MeshRenderer:
+  m_Materials:
+  - {fileID: 2100000, guid: 0000000000000000f000000000000000, type: 0}
+--- !u!54 &54
+Rigidbody:
+  m_Mass: 1

--- a/Assets/Prefabs/Cube.prefab.meta
+++ b/Assets/Prefabs/Cube.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: adac71fa928d42aea00f2f6542227e10
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Prefabs/Obstacle.prefab
+++ b/Assets/Prefabs/Obstacle.prefab
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: Obstacle
+  m_Component:
+  - component: {fileID: 4}
+  - component: {fileID: 33}
+  - component: {fileID: 23}
+  - component: {fileID: 54}
+  m_Layer: 0
+  m_IsActive: 1
+--- !u!4 &4
+Transform:
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &33
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 0000000000000000f000000000000000, type: 0}
+--- !u!23 &23
+MeshRenderer:
+  m_Materials:
+  - {fileID: 2100000, guid: 0000000000000000f000000000000000, type: 0}
+--- !u!65 &54
+BoxCollider:
+  m_IsTrigger: 0
+--- !u!114 &75
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 3}
+  speed: 4

--- a/Assets/Prefabs/Obstacle.prefab.meta
+++ b/Assets/Prefabs/Obstacle.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5f82059e928e424c99f166f6b2d7eaa9
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -318,6 +318,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1000000002}
   - component: {fileID: 1000000001}
+  - component: {fileID: 1000000003}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -338,6 +339,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   jumpForce: 5
+--- !u!114 &1000000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62da53cf002c4f17bc532b0aa9e48e13, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  cubePrefab: {fileID: 100000, guid: adac71fa928d42aea00f2f6542227e10, type: 3}
+  obstaclePrefab: {fileID: 100000, guid: 5f82059e928e424c99f166f6b2d7eaa9, type: 3}
+  canvasPrefab: {fileID: 100000, guid: abd02747c79b4128ba4324bdfe3f086b, type: 3}
 --- !u!4 &1000000002
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CubeGame.cs
+++ b/Assets/Scripts/CubeGame.cs
@@ -5,6 +5,7 @@ public class CubeGame : MonoBehaviour
     public float jumpForce = 50f;
 
     private CubeModel model;
+    [SerializeField]
     private CubeView view;
 
     const float floorLimit = 0.5f;
@@ -13,12 +14,19 @@ public class CubeGame : MonoBehaviour
     void Start()
     {
         model = new CubeModel();
-        view = new CubeView();
-        view.SetupScene();
-        model.StartGame();
+        if (view == null)
+        {
+            view = FindObjectOfType<CubeView>();
+        }
 
-        view.JumpButton.onClick.AddListener(ApplyJump);
-        view.RestartButton.onClick.AddListener(view.RestartScene);
+        if (view != null)
+        {
+            view.SetupScene();
+            model.StartGame();
+
+            view.JumpButton.onClick.AddListener(ApplyJump);
+            view.RestartButton.onClick.AddListener(view.RestartScene);
+        }
     }
 
     void ApplyJump()

--- a/Assets/Scripts/CubeView.cs
+++ b/Assets/Scripts/CubeView.cs
@@ -3,8 +3,12 @@ using UnityEngine.UI;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 
-public class CubeView
+public class CubeView : MonoBehaviour
 {
+    [SerializeField] private GameObject cubePrefab;
+    [SerializeField] private GameObject obstaclePrefab;
+    [SerializeField] private GameObject canvasPrefab;
+
     public Rigidbody CubeRb { get; private set; }
     public Text ResultText { get; private set; }
     public Button JumpButton { get; private set; }
@@ -13,10 +17,20 @@ public class CubeView
     public void SetupScene()
     {
         // Create Cube
-        GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-        cube.transform.position = new Vector3(0f, 5f, 0f);
+        GameObject cube = null;
+        if (cubePrefab != null)
+        {
+            cube = Instantiate(cubePrefab, new Vector3(0f, 5f, 0f), Quaternion.identity);
+        }
+        else
+        {
+            cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.position = new Vector3(0f, 5f, 0f);
+        }
         cube.tag = "Player";
-        CubeRb = cube.AddComponent<Rigidbody>();
+        CubeRb = cube.GetComponent<Rigidbody>();
+        if (CubeRb == null)
+            CubeRb = cube.AddComponent<Rigidbody>();
 
         // Create Ground
         GameObject ground = GameObject.CreatePrimitive(PrimitiveType.Plane);
@@ -27,11 +41,16 @@ public class CubeView
         ScrollingTexture groundScroll = ground.AddComponent<ScrollingTexture>();
 
         // Obstacle prefab
-        GameObject obstaclePrefab = GameObject.CreatePrimitive(PrimitiveType.Cube);
-        obstaclePrefab.GetComponent<Renderer>().material.color = Color.red;
-        obstaclePrefab.AddComponent<BoxCollider>();
-        Obstacle obstacleComponent = obstaclePrefab.AddComponent<Obstacle>();
-        obstaclePrefab.SetActive(false);
+        Obstacle obstacleComponent = obstaclePrefab != null ? obstaclePrefab.GetComponent<Obstacle>() : null;
+        if (obstacleComponent == null)
+        {
+            GameObject temp = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            obstacleComponent = temp.AddComponent<Obstacle>();
+            temp.AddComponent<BoxCollider>();
+            temp.GetComponent<Renderer>().material.color = Color.red;
+            obstaclePrefab = temp;
+            obstaclePrefab.SetActive(false);
+        }
         groundScroll.worldScrollSpeed = obstacleComponent.speed;
 
         // Spawner
@@ -53,71 +72,45 @@ public class CubeView
         ceilingScroll.worldScrollSpeed = obstacleComponent.speed;
 
         // Create Canvas
-        GameObject canvasGO = new GameObject("Canvas");
-        Canvas canvas = canvasGO.AddComponent<Canvas>();
-        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
-        canvasGO.AddComponent<CanvasScaler>();
-        canvasGO.AddComponent<GraphicRaycaster>();
+        GameObject canvasGO = null;
+        if (canvasPrefab != null)
+        {
+            canvasGO = Instantiate(canvasPrefab);
+        }
+        else
+        {
+            canvasGO = new GameObject("Canvas");
+            Canvas canvas = canvasGO.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvasGO.AddComponent<CanvasScaler>();
+            canvasGO.AddComponent<GraphicRaycaster>();
 
-        // Event System for UI interaction
-        GameObject eventSystemGO = new GameObject("EventSystem");
-        eventSystemGO.AddComponent<EventSystem>();
-        eventSystemGO.AddComponent<StandaloneInputModule>();
+            // Event System for UI interaction
+            GameObject eventSystemGO = new GameObject("EventSystem");
+            eventSystemGO.AddComponent<EventSystem>();
+            eventSystemGO.AddComponent<StandaloneInputModule>();
+        }
 
         // Jump Button
-        GameObject buttonGO = new GameObject("JumpButton");
-        buttonGO.transform.SetParent(canvasGO.transform);
-        JumpButton = buttonGO.AddComponent<Button>();
-        Image btnImage = buttonGO.AddComponent<Image>();
-        btnImage.color = Color.white;
-        RectTransform btnRect = buttonGO.GetComponent<RectTransform>();
-        btnRect.sizeDelta = new Vector2(160, 30);
-        btnRect.anchoredPosition = new Vector2(0, 50);
-        Text btnText = new GameObject("Text").AddComponent<Text>();
-        btnText.transform.SetParent(buttonGO.transform);
-        btnText.text = "Jump";
-        btnText.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
-        btnText.alignment = TextAnchor.MiddleCenter;
-        btnText.color = Color.black;
-        RectTransform textRect = btnText.GetComponent<RectTransform>();
-        textRect.anchorMin = Vector2.zero;
-        textRect.anchorMax = Vector2.one;
-        textRect.offsetMin = Vector2.zero;
-        textRect.offsetMax = Vector2.zero;
+        Transform jumpT = canvasGO.transform.Find("JumpButton");
+        if (jumpT != null)
+        {
+            JumpButton = jumpT.GetComponent<Button>();
+        }
 
         // Restart Button
-        GameObject restartGO = new GameObject("RestartButton");
-        restartGO.transform.SetParent(canvasGO.transform);
-        RestartButton = restartGO.AddComponent<Button>();
-        Image restartImage = restartGO.AddComponent<Image>();
-        restartImage.color = Color.white;
-        RectTransform restartRect = restartGO.GetComponent<RectTransform>();
-        restartRect.sizeDelta = new Vector2(160, 30);
-        restartRect.anchoredPosition = new Vector2(0, 10);
-        Text restartText = new GameObject("Text").AddComponent<Text>();
-        restartText.transform.SetParent(restartGO.transform);
-        restartText.text = "Restart";
-        restartText.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
-        restartText.alignment = TextAnchor.MiddleCenter;
-        restartText.color = Color.black;
-        RectTransform restartTextRect = restartText.GetComponent<RectTransform>();
-        restartTextRect.anchorMin = Vector2.zero;
-        restartTextRect.anchorMax = Vector2.one;
-        restartTextRect.offsetMin = Vector2.zero;
-        restartTextRect.offsetMax = Vector2.zero;
+        Transform restartT = canvasGO.transform.Find("RestartButton");
+        if (restartT != null)
+        {
+            RestartButton = restartT.GetComponent<Button>();
+        }
 
         // Result Text
-        GameObject textGO = new GameObject("ResultText");
-        textGO.transform.SetParent(canvasGO.transform);
-        ResultText = textGO.AddComponent<Text>();
-        ResultText.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
-        ResultText.fontSize = 24;
-        ResultText.alignment = TextAnchor.MiddleCenter;
-        ResultText.horizontalOverflow = HorizontalWrapMode.Overflow;
-        ResultText.verticalOverflow = VerticalWrapMode.Overflow;
-        RectTransform resultRect = ResultText.GetComponent<RectTransform>();
-        resultRect.sizeDelta = new Vector2(300, 40);
-        resultRect.anchoredPosition = new Vector2(0, -50);
+        Transform resultT = canvasGO.transform.Find("ResultText");
+        if (resultT != null)
+        {
+            ResultText = resultT.GetComponent<Text>();
+        }
     }
 
     public void ShowResult(float time, float highScore)

--- a/Assets/Scripts/CubeView.cs.meta
+++ b/Assets/Scripts/CubeView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62da53cf002c4f17bc532b0aa9e48e13
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- convert `CubeView` to `MonoBehaviour`
- reference cube, obstacle and canvas prefabs
- look up the existing `CubeView` from `CubeGame`
- add placeholder prefabs and wire them in `SampleScene`

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*
- `pytest -q` *(fails: command not found)*