### PR TITLE
Stop game objects when player dies

### DIFF
--- a/Assets/Scripts/CubeGame.cs
+++ b/Assets/Scripts/CubeGame.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 
 public class CubeGame : MonoBehaviour
 {
+    public static CubeGame Instance { get; private set; }
     public float jumpForce = 50f;
 
     private CubeModel model;
@@ -10,6 +11,17 @@ public class CubeGame : MonoBehaviour
 
     const float floorLimit = 0.5f;
     const float ceilingLimit = 9.5f;
+
+    void Awake()
+    {
+        Instance = this;
+    }
+
+    void OnDestroy()
+    {
+        if (Instance == this)
+            Instance = null;
+    }
 
     void Start()
     {

--- a/Assets/Scripts/Obstacle.cs
+++ b/Assets/Scripts/Obstacle.cs
@@ -7,6 +7,9 @@ public class Obstacle : MonoBehaviour
 
     void Update()
     {
+        if (CubeGame.Instance != null && CubeGame.Instance.GameOver)
+            return;
+
         transform.position += Vector3.left * speed * Time.deltaTime;
         if (transform.position.x < leftLimit)
         {
@@ -18,10 +21,9 @@ public class Obstacle : MonoBehaviour
     {
         if (other.gameObject.CompareTag("Player"))
         {
-            CubeGame game = FindObjectOfType<CubeGame>();
-            if (game != null)
+            if (CubeGame.Instance != null)
             {
-                game.TriggerGameOver();
+                CubeGame.Instance.TriggerGameOver();
             }
         }
     }

--- a/Assets/Scripts/ObstacleSpawner.cs
+++ b/Assets/Scripts/ObstacleSpawner.cs
@@ -35,6 +35,9 @@ public class ObstacleSpawner : MonoBehaviour
 
     void Update()
     {
+        if (CubeGame.Instance != null && CubeGame.Instance.GameOver)
+            return;
+
         timer += Time.deltaTime;
         if (timer >= spawnInterval)
         {

--- a/Assets/Scripts/ScrollingTexture.cs
+++ b/Assets/Scripts/ScrollingTexture.cs
@@ -23,6 +23,9 @@ public class ScrollingTexture : MonoBehaviour
 
     void Update()
     {
+        if (CubeGame.Instance != null && CubeGame.Instance.GameOver)
+            return;
+
         if (rend == null || rend.material == null) return;
 
         float uvWidth = 10f * transform.localScale.x; // world units that correspond to 1 offset unit


### PR DESCRIPTION
## Summary
- stop floor/ceiling material scrolling when the game is over
- stop obstacle motion and spawning while game is over
- expose `CubeGame.Instance` to make game state accessible

## Testing
- `git status --short`